### PR TITLE
Changed when pairing messages start getting sent

### DIFF
--- a/db/crud.py
+++ b/db/crud.py
@@ -20,9 +20,9 @@ def get_channel(db: Session, channel_id: str, team_id: str) -> models.Channels:
     )
 
 
-def get_channels_eligible_for_pairing(db: Session, limit: int = 10):
+def get_channels_eligible_for_pairing(db: Session, limit: int = 10, curr_date=datetime.utcnow()):
     # TODO: instead of being default of 2 weeks, allow per channel configuration of frequency of pairing
-    two_weeks_ago_date = datetime.utcnow() - timedelta(14)
+    two_weeks_ago_date = curr_date - timedelta(14)
     return (
         db.query(models.Channels)
         .where(

--- a/tasks.py
+++ b/tasks.py
@@ -43,7 +43,7 @@ def match_pairs_periodic():
     # TODO: If another task starts while previous one is already running that can potentially add issues, use mutex to prevent that
     # Instead of start sending messages at sunday night, this makes the day start at 9am EST. TODO: Make it configurable per channel
     today = datetime.utcnow() - timedelta(hours=14)
-    if today.weekday() != int(os.environ.get("CONVERSATION_DAY", 6)):
+    if today.weekday() != int(os.environ.get("CONVERSATION_DAY", 0)):
         return
 
     with database.SessionLocal() as db:


### PR DESCRIPTION
Currently the pairing message is sent at UTC midnight, which is sunday night for most timezones. Change this behavior so that messages start getting sent at 9am EST. Ideally, change this to use slack's schedule message API as this task can run for long and some users will get message late on Sunday. 